### PR TITLE
Fix SigLevel syntax

### DIFF
--- a/templates/pacman.conf.repo.erb
+++ b/templates/pacman.conf.repo.erb
@@ -5,7 +5,7 @@
 <% end -%>
 # Order: <%= @order %>
 <%if @siglevel -%>
-SigLevel <%= @siglevel %>
+SigLevel = <%= @siglevel %>
 <% end -%>
 <%if @server -%>
 Server = <%= @server %>


### PR DESCRIPTION
usage of siglevel for custom repo caused pacman parsing errors due to missing "="
