### PR TITLE
Fix typo in pacman.conf template

### DIFF
--- a/templates/pacman.conf.main.erb
+++ b/templates/pacman.conf.main.erb
@@ -10,7 +10,7 @@
 # The following paths are commented out with their default values listed.
 # If you wish to use different paths, uncomment and update the paths.
 #RootDir     = /
-Rootdir      = <%= @rootdir %>
+RootDir      = <%= @rootdir %>
 
 #DBPath      = /var/lib/pacman/
 DBPath       = <%= @dbpath %>


### PR DESCRIPTION
The correct config name is RootDir, not Rootdir (the commented line is correct btw)
