### PR TITLE
Update pacman package name to be a string

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class pacman::params {
   case $::osfamily {
     'Archlinux' : {
       $package_ensure = 'present'
-      $package_name = ['pacman']
+      $package_name = 'pacman'
       $config = '/etc/pacman.conf'
       # pacman config options
       $rootdir = '/'


### PR DESCRIPTION
In latest versions puppet the package name must be a string.
See: https://groups.google.com/forum/#!topic/puppet-users/gxwDg8XUVqw
